### PR TITLE
Migrate into @oasisprotocol

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-
-# Only the creator of the repo and the oasislabs admins
-# can manage the github settings of this repository
-.github/ @Yawning @willscott @oasislabs/admin
+* @kostko @peterjgilbert

--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,1 +1,0 @@
-_extends: private-global-settings

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,0 @@
-_extends: private-global-settings
-
-collaborators:
-  - username: willscott
-    permission: admin

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### deoxysii.js - JavaScript Deoxys-II-256-128
-![GitHub CI](https://github.com/oasislabs/deoxysii.js/actions/workflows/config.yml/badge.svg)
+![GitHub CI](https://github.com/oasisprotocol/deoxysii-js/actions/workflows/config.yml/badge.svg)
 
 > When I find my code in tons of trouble,
 > Friends and colleagues come to me,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "deoxysii",
+  "name": "@oasisprotocol/deoxysii",
   "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/deoxysii",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deoxysii",
+  "name": "@oasisprotocol/deoxysii",
   "version": "0.0.3",
   "description": "Deoxys-II-256-128",
   "main": "./deoxysii",
@@ -12,10 +12,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oasislabs/deoxysii.js.git"
+    "url": "https://github.com/oasisprotocol/deoxysii-js.git"
   },
   "license": "MIT",
-  "author": "Oasis Labs Inc. <info@oasislabs.com>",
+  "author": "Oasis Protocol Foundation <info@oasisprotocol.org>",
   "devDependencies": {
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/deoxysii",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Deoxys-II-256-128",
   "main": "./deoxysii",
   "types": "./deoxysii.d.ts",


### PR DESCRIPTION
https://www.npmjs.com/package/deoxysii is owned by willscott
so we can't publish https://github.com/oasislabs/deoxysii.js/pull/30